### PR TITLE
Add unsafe & replace sleep_ms with sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ fn main() {
     d.add('sound id 3',s3)
 
     s1.play()
-    time.sleep_ms(50)
+    time.sleep(50*time.millisecond)
     s3.play()
-    time.sleep_ms(200)
+    time.sleep(200*time.millisecond)
     s3.seek(20)
     s2.play()
 
@@ -46,12 +46,12 @@ fn main() {
     for ee := s1.length(); ee > 0; ee = ee - 16.377 {
         vol = vol - 0.016
         s1.volume(vol)
-        time.sleep_ms(16)
+        time.sleep(16*time.millisecond)
     }
 
     mut longest := int(math.max(s1.length(), s2.length()))
     longest = int(math.max(longest, s3.length()))
-    time.sleep_ms(longest)
+    time.sleep(longest*time.millisecond)
 
     d.free()
 

--- a/miniaudio.v
+++ b/miniaudio.v
@@ -440,46 +440,56 @@ pub fn (mut s Sound) pause() {
 }
 
 pub fn (s Sound) length() f64 {
-	if s.audio_buffer == 0 {
-		return f64(0)
+	unsafe{
+		if s.audio_buffer == 0 {
+			return f64(0)
+		}
+		return s.audio_buffer.length()
 	}
-	return s.audio_buffer.length()
 }
 
 pub fn (s Sound) pcm_frames() u64 {
-	if s.audio_buffer == 0 {
-		return u64(0)
+	unsafe{
+		if s.audio_buffer == 0 {
+			return u64(0)
+		}
+		return s.audio_buffer.pcm_frames()
 	}
-	return s.audio_buffer.pcm_frames()
 }
 
 pub fn (s Sound) sample_rate() u32 {
-	if s.audio_buffer == 0 {
-		return u32(0)
+	unsafe{
+		if s.audio_buffer == 0 {
+			return u32(0)
+		}
+		return s.audio_buffer.sample_rate()
 	}
-	return s.audio_buffer.sample_rate()
 }
 
 pub fn (mut s Sound) volume(volume f64) {
-	if s.audio_buffer == 0 {
-		return
+	unsafe{
+		if s.audio_buffer == 0 {
+			return
+		}
+		mut value := volume
+		if value < 0 {
+			value = 0.0
+		}
+		if value > 1 {
+			value = 1.0
+		}
+		// $if debug { println('Sound '+ptr_str(s)+' -> volume: '+value.str()) }
+		s.audio_buffer.set_volume(value)
 	}
-	mut value := volume
-	if value < 0 {
-		value = 0.0
-	}
-	if value > 1 {
-		value = 1.0
-	}
-	// $if debug { println('Sound '+ptr_str(s)+' -> volume: '+value.str()) }
-	s.audio_buffer.set_volume(value)
 }
 
 pub fn (mut s Sound) seek(ms f64) {
-	if s.audio_buffer == 0 {
-		return
+	unsafe{
+		if s.audio_buffer == 0 {
+			return
+		}
+		s.audio_buffer.seek(ms)
 	}
-	s.audio_buffer.seek(ms)
 }
 
 pub fn (mut s Sound) free() {

--- a/miniaudio.v
+++ b/miniaudio.v
@@ -426,8 +426,8 @@ pub fn sound_from(filename string) Sound {
 /*
 * Sound
 */
-struct Sound {
-mut:
+pub struct Sound {
+pub mut:
 	audio_buffer &AudioBuffer
 }
 
@@ -517,8 +517,8 @@ fn (s Stream) audio_buffer() AudioBuffer {
 * AudioBuffer
 */
 
-struct AudioBuffer {
-mut:
+pub struct AudioBuffer {
+pub mut:
 	// dsp                         C.ma_pcm_converter // PCM data converter
 	decoder &C.ma_decoder
 	volume  f64 // Audio buffer volume


### PR DESCRIPTION
> Fix compile errors like this

```miniaudio/miniaudio.v:443:7: error: infix expr: cannot use `int literal` (right expression) as `miniaudio.AudioBuffer`  (you can use it inside an `unsafe` block)```

> Replace deprecated `sleep_ms` with `sleep`